### PR TITLE
Update the tool to use the 'del.icio.us' URL across the board 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.bbprojectd
+/nbproject/private/

--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Delicious-Chrome-Extension
 Adds a Del.icio.us button in your Chrome Toolbar.  http://ghettocooler.net/2011/08/29/delicious-chrome-extension/
 
 Install via the Chrome web store:
+
 https://chrome.google.com/webstore/detail/gclkcflnjahgejhappicbhcpllkpakej

--- a/background.js
+++ b/background.js
@@ -45,7 +45,7 @@ chrome.webRequest.onCompleted.addListener(
 	function(details){
 		// We're only here IF the XHR request is the URL found under filters
 		// console.log("resource", details.url);
-		// we also need to make sure this is OUR popup, as opposed to the live delicious.com
+		// we also need to make sure this is OUR popup, as opposed to the live del.icio.us
 		chrome.tabs.query({
 			active: true,                              // Select active tabs
 			windowId: chrome.windows.WINDOW_ID_CURRENT // In the current window
@@ -64,8 +64,8 @@ chrome.webRequest.onCompleted.addListener(
 	// filters
 	{
 		urls: [
-			"*://*.delicious.com/api/v1/posts/addoredit*",
-			"*://*.delicious.com/api/v1/posts/delete*"
+			"*://*.del.icio.us/api/v1/posts/addoredit*",
+			"*://*.del.icio.us/api/v1/posts/delete*"
 		]
 	}
 );
@@ -155,7 +155,7 @@ addDelicious = function(conf) {
 		notes = c.notes || "",
 		w = c.width || 500,
 		h = c.height || 463,
-		deliciousUrl = c.deliciousUrl || "https://delicious.com/save?v=5&noui&url=",
+		deliciousUrl = c.deliciousUrl || "https://del.icio.us/save?v=5&noui&url=",
 		fullUrl,
 		autoClose = c.autoClose || true;
 

--- a/manifest.json
+++ b/manifest.json
@@ -16,14 +16,14 @@
 	},
 	"options_page": "options_shortcut.html",
 	"permissions": [
-		"http://delicious.com/*",
-		"http://feeds.delicious.com/*",
+		"http://del.icio.us/*",
+		"http://feeds.del.icio.us/*",
 		"tabs",
 		"http://*/",
 		"https://*/",
 		"webRequest",
-    	"*://*.delicious.com/api/v1/posts/addoredit*",
-    	"*://*.delicious.com/api/v1/posts/delete*",
+    	"*://*.del.icio.us/api/v1/posts/addoredit*",
+    	"*://*.del.icio.us/api/v1/posts/delete*",
     	"https://ajax.googleapis.com/*"
 
 	],

--- a/manifest.json
+++ b/manifest.json
@@ -6,12 +6,12 @@
 			"matches": ["http://*/*","https://*/*"]
 		}
 	],
-	"name": "Delicious Tools",
-	"version": "1.8",
+	"name": "Del.icio.us Tools",
+	"version": "1.9",
 	"manifest_version": 2,
 	"minimum_chrome_version": "17",
 	"content_security_policy": "script-src 'self' https://ajax.googleapis.com; object-src 'self'",
-	"description": "Quick access to saving Delicious bookmarks. Customizable keyboard shortcut. Selected text populates your notes field.",
+	"description": "Quick access to saving Del.icio.us bookmarks. Customizable keyboard shortcut. Selected text populates your notes field.",
 	"icons" : {"48": "delicious48.png", "128": "delicious128.png"
 	},
 	"options_page": "options_shortcut.html",
@@ -28,12 +28,11 @@
 
 	],
 	"browser_action": {
-		"default_title": "Delicious",
+		"default_title": "Del.icio.us",
 		"default_icon": "delicious.png"
-		
+
 	},
 	"background": {
 		"scripts": ["background.js","options_shortcut.js"]
 	}
 }
-

--- a/options_shortcut.html
+++ b/options_shortcut.html
@@ -27,7 +27,7 @@
 
 		<fieldset>
 				<legend>Release Notes:</legend>
-				<p><strong>Version 1.8 (1/2/2015)</strong>: Save window will no longer auto-close if you're hovering over it (Default Delicious.com behavior).</p>
+				<p><strong>Version 1.8 (1/2/2015)</strong>: Save window will no longer auto-close if you're hovering over it (Default del.icio.us behavior).</p>
 				<p><strong>Version 1.7 (5/1/2014)</strong>: Finally fixes a serious issue where bookmarks were not being saved to your Delicious account unless you saved them twice, or were logged in to Delcious.com in a seperate tab. <a href="http://ghettocooler.net/2014/05/01/delicious-tools-chrome-extension-release-notes-v-1-7/" title="ghettocooler.net">Read More</a>.
 		</fieldset>
 


### PR DESCRIPTION
It seems that that original domain name 'delicious.com' is no longer active. This pull request updates the the chrome extension to use 'del.icio.us' as the domain name in all cases.